### PR TITLE
Bclconversion script change/upgrade

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,4 @@
 genologics
+couchdb
+numpy
+click

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,1 @@
 genologics
-couchdb
-numpy
-click

--- a/scripts/manage_demux_stats.py
+++ b/scripts/manage_demux_stats.py
@@ -66,7 +66,7 @@ def manipulate_workflow(demux_process):
                 proc_stats["Instrument"] = "hiseq"
             elif "Illumina Sequencing (HiSeq X) 1.0" in k:
                 proc_stats["Chemistry"] ="HiSeqX v2.5"
-                proc_stats["Instrument"] = "hiseqx"
+                proc_stats["Instrument"] = "HiSeq_X"
             else:
                 problem_handler("exit", "Unhandled prior workflow step (run type)")
             logger.info("Run type/chemistry set to {}".format(proc_stats["Chemistry"]))

--- a/scripts/manage_demux_stats.py
+++ b/scripts/manage_demux_stats.py
@@ -41,22 +41,27 @@ def problem_handler(type, message):
 def manipulate_workflow(demux_process):
     try:
         workflow = lims.get_processes(inputartifactlimsid = demux_process.all_inputs()[0].id)
+        for elem in workflow:
+            if elem.type.name in {"MiSeq Run (MiSeq) 4.0","Illumina Sequencing (Illumina SBS) 4.0",\
+                                   "Illumina Sequencing (HiSeq X) 1.0"}:
+                sequencing_name = elem.type.name
+                #Copies LIMS sequencing step content
+                proc_stats = dict(elem.udf.items())
     except:
         problem_handler("exit", "Undefined prior workflow step (run type)")
-    #Copies LIMS sequencing step content
-    proc_stats = dict(workflow[0].udf.items())
+    
     #Instrument is denoted the way it is since it is also used to find
     #the folder of the laneBarcode.html file
-    if "MiSeq Run (MiSeq) 4.0" == workflow[0].type.name:
+    if "MiSeq Run (MiSeq) 4.0" == sequencing_name:
         proc_stats["Chemistry"] ="MiSeq"
         proc_stats["Instrument"] = "miseq"
-    elif "Illumina Sequencing (Illumina SBS) 4.0" == workflow[0].type.name:
+    elif "Illumina Sequencing (Illumina SBS) 4.0" == sequencing_name:
         try:
             proc_stats["Chemistry"] = workflow[0].udf["Flow Cell Version"]
         except:
             problem_handler("exit", "No flowcell version set in sequencing step.")
         proc_stats["Instrument"] = "hiseq"
-    elif "Illumina Sequencing (HiSeq X) 1.0" == workflow[0].type.name:
+    elif "Illumina Sequencing (HiSeq X) 1.0" == sequencing_name:
         proc_stats["Chemistry"] ="HiSeqX v2.5"
         proc_stats["Instrument"] = "HiSeq_X"
     else:

--- a/scripts/manage_demux_stats.py
+++ b/scripts/manage_demux_stats.py
@@ -39,29 +39,25 @@ def problem_handler(type, message):
 
 """Fetches overarching workflow info"""
 def manipulate_workflow(demux_process):
+    run_types = {"MiSeq Run (MiSeq) 4.0","Illumina Sequencing (Illumina SBS) 4.0","Illumina Sequencing (HiSeq X) 1.0"}
     try:
-        workflow = lims.get_processes(inputartifactlimsid = demux_process.all_inputs()[0].id)
-        for elem in workflow:
-            if elem.type.name in {"MiSeq Run (MiSeq) 4.0","Illumina Sequencing (Illumina SBS) 4.0",\
-                                   "Illumina Sequencing (HiSeq X) 1.0"}:
-                sequencing_name = elem.type.name
-                #Copies LIMS sequencing step content
-                proc_stats = dict(elem.udf.items())
+        workflow = lims.get_processes(inputartifactlimsid = demux_process.all_inputs()[0].id, type=run_types)[0]
     except:
         problem_handler("exit", "Undefined prior workflow step (run type)")
-    
+    #Copies LIMS sequencing step content
+    proc_stats = dict(workflow.udf.items())
     #Instrument is denoted the way it is since it is also used to find
     #the folder of the laneBarcode.html file
-    if "MiSeq Run (MiSeq) 4.0" == sequencing_name:
+    if "MiSeq Run (MiSeq) 4.0" == workflow.type.name:
         proc_stats["Chemistry"] ="MiSeq"
         proc_stats["Instrument"] = "miseq"
-    elif "Illumina Sequencing (Illumina SBS) 4.0" == sequencing_name:
+    elif "Illumina Sequencing (Illumina SBS) 4.0" == workflow.type.name:
         try:
             proc_stats["Chemistry"] = workflow[0].udf["Flow Cell Version"]
         except:
             problem_handler("exit", "No flowcell version set in sequencing step.")
         proc_stats["Instrument"] = "hiseq"
-    elif "Illumina Sequencing (HiSeq X) 1.0" == sequencing_name:
+    elif "Illumina Sequencing (HiSeq X) 1.0" == workflow.type.name:
         proc_stats["Chemistry"] ="HiSeqX v2.5"
         proc_stats["Instrument"] = "HiSeq_X"
     else:

--- a/scripts/manage_demux_stats.py
+++ b/scripts/manage_demux_stats.py
@@ -1,0 +1,289 @@
+#!/usr/bin/env python
+"""
+This file together with manage_demux_stats_thresholds.py performs the "bclconversion" step of LIMS workflow.
+In common tongue, it:
+ 
+Fetches info from the sequencing process (RunID, FCID; derives instrument and data type)
+Assigns (Q30, Clust per Lane) thresholds to the process (workflow step)
+Reformats laneBarcode.html to "demuxstats_FCID.csv" for usage of other applications
+Assigns a lot of info from laneBarcode.html to individual samples of the process (e.g. %PF)
+Flags samples as QC PASSED/FAILED based on thresholds
+
+Written by Isak Sylvin; isak.sylvin@scilifelab.se"""
+
+#Fetched from SciLife repos
+from genologics.lims import Lims
+from genologics.config import BASEURI, USERNAME, PASSWORD
+from genologics.entities import Process
+from genologics.epp import EppLogger, attach_file
+import flowcell_parser.classes as classes
+from manage_demux_stats_thresholds import Thresholds
+
+#Standard packages
+from shutil import move
+import os 
+import click
+import csv
+import sys
+import logging
+
+"""Fetches overarching workflow info"""
+def manipulate_workflow(demux_process):
+    try:
+        demux_container = demux_process.all_inputs()[0].location[0].name    
+    except:
+        sys.exit("Container name not found")
+        
+    workflow_types = {"MiSeq Run (MiSeq) 4.0":"Reagent Cartridge ID", "Illumina Sequencing (Illumina SBS) 4.0":"Flow Cell ID",
+              "Illumina Sequencing (HiSeq X) 1.0":"Flow Cell ID"}
+    for k,v in workflow_types.items():
+        #Sequencing step is null if it doesn"t exist
+        workflow = lims.get_processes(udf = {v : demux_container}, type = k)
+        #If sequencing step key exists
+        if(workflow):
+            #Copies LIMS sequencing step content
+            proc_stats = dict(workflow[0].udf.items())
+            #Instrument is denoted the way it is since it is also used to find
+            #the folder of the laneBarcode.html file
+            if "MiSeq Run (MiSeq) 4.0" in k:
+                proc_stats["Chemistry"] ="MiSeq"
+                proc_stats["Instrument"] = "miseq"
+            elif "Illumina Sequencing (Illumina SBS) 4.0" in k:
+                try:
+                    proc_stats["Chemistry"] = workflow[0].udf["Flow Cell Version"]
+                except:
+                    sys.exit("No flowcell version set in sequencing step.")
+                proc_stats["Instrument"] = "hiseq"
+            elif "Illumina Sequencing (HiSeq X) 1.0" in k:
+                proc_stats["Chemistry"] ="HiSeqX v2.5"
+                proc_stats["Instrument"] = "hiseqx"
+            else:
+                sys.exit("Unhandled prior workflow step (run type)")
+            logging.info("Run type set to {}".format(proc_stats["Chemistry"]))
+            break
+    
+    try:
+        proc_stats["Paired"] = False
+    except:
+        sys.exit("Unable to fetch workflow information.")
+    if "Read 2 Cycles" in proc_stats:
+        proc_stats["Paired"] = True
+    logging.info("Paired libraries: {}".format(str(proc_stats["Paired"])))  
+    #Assignment to make usage more explicit
+    try:
+        proc_stats["Read Length"] = proc_stats["Read 1 Cycles"]
+    except:
+        sys.exit("Read 1 Cycles not found. Unable to read Read Length")
+    return proc_stats
+
+"""Sets run thresholds"""
+def manipulate_process(demux_process, proc_stats):      
+    thresholds = Thresholds(proc_stats["Instrument"], proc_stats["Chemistry"], proc_stats["Paired"], proc_stats["Read Length"])
+        
+    if not "Threshold for % bases >= Q30" in demux_process.udf:
+        try:
+            demux_process.udf["Threshold for % bases >= Q30"] = thresholds.Q30
+            logging.info("Q30 threshold set to {}".format(str(demux_process.udf["Threshold for % bases >= Q30"])))
+        except:
+            sys.exit("Udf improperly formatted. Unable to set Q30 threshold")
+    #Would REALLY prefer "Minimum Reads per Lane" over "Threshold for # Reads"
+    if not "Minimum Reads per Lane" in demux_process.udf:
+        try:
+            demux_process.udf["Minimum Reads per Lane"] = thresholds.exp_lane_clust
+            logging.info("Minimum clusters per lane set to {}".format(str(demux_process.udf["Minimum Reads per Lane"])))
+        except:
+            sys.exit("Udf improperly formatted. Unable to set # Reads threshold")
+    
+    #Would REALLY prefer "Maximum % Undetermined Reads per Lane" over "Threshold for Undemultiplexed Index Yield"
+    if not "Maximum % Undetermined Reads per Lane" in demux_process.udf:
+        try:
+            demux_process.udf["Maximum % Undetermined Reads per Lane"] = thresholds.undet_indexes_perc
+            logging.info("Maximum percentage of undetermined per lane set to {} %".format(str(demux_process.udf["Maximum % Undetermined Reads per Lane"])))
+        except:
+            sys.exit("Udf improperly formatted. Unable to set Undemultiplexed Index Yield threshold")
+
+    #Sets Run ID if not already exists:
+    if not "Run ID" in demux_process.udf:
+        try:
+            demux_process.udf["Run ID"] = proc_stats["Run ID"]
+        except:
+            logging.info("Unable to automatically regenerate Run ID")
+    #Checks for document version
+    if not "Document Version" in demux_process.udf:
+        sys.exit("No Document Version set. Please set one.")
+    try:
+        demux_process.put()
+    except:
+        sys.exit("Failed to apply process thresholds to LIMS")
+    
+"""Sets artifact = samples values """
+def set_sample_values(demux_process, parser_struct, proc_stats):
+    for pool in demux_process.all_inputs():
+        try:
+            outarts_per_lane = demux_process.outputs_per_input(pool.id, ResultFile = True)
+        except:
+            sys.exit("Unable to fetch artifacts of process")
+        if proc_stats["Instrument"] == "miseq":
+            lane_no = "1"
+        else:
+            try:
+                lane_no = pool.location[1][0]
+            except:
+                sys.exit("Unable to determine lane number. Incorrect location variable in process.")
+        logging.info("Lane number set to {}".format(lane_no))
+        exp_smp_per_lne = round(demux_process.udf["Minimum Reads per Lane"]/float(len(outarts_per_lane)), 0)
+        logging.info("Expected sample clusters for this lane: {}".format(str(exp_smp_per_lne)))
+        
+        assign_lane_reads = 0
+        undet_lane_reads = 0
+        for target_file in outarts_per_lane:
+            try:
+                current_name = target_file.samples[0].name
+            except:
+                sys.exit("Unable to determine sample name. Incorrect sample variable in process.")
+            for entry in parser_struct:
+                if lane_no == entry["Lane"]:
+                    sample = entry["Sample"]
+                    if sample == current_name:
+                        logging.info("Added the following set of values to {} of lane {}:".format(sample,lane_no))
+                        try:
+                            target_file.udf["%PF"] = float(entry["% PFClusters"])
+                            logging.info("{}% PF".format(str(target_file.udf["%PF"])))
+                            target_file.udf["% One Mismatch Reads (Index)"] = float(entry["% One mismatchbarcode"])
+                            logging.info("{}% One Mismatch Reads (Index)".format(str(target_file.udf["% One Mismatch Reads (Index)"])))
+                            target_file.udf["% of Raw Clusters Per Lane"] = float(entry["% of thelane"])
+                            logging.info("{}% of Raw Clusters Per Lane".format(str(target_file.udf["% of Raw Clusters Per Lane"])))
+                            target_file.udf["Ave Q Score"] = float(entry["Mean QualityScore"])
+                            logging.info("{}Ave Q Score".format(str(target_file.udf["Ave Q Score"])))
+                            target_file.udf["% Perfect Index Read"] = float(entry["% Perfectbarcode"])
+                            logging.info("{}% Perfect Index Read".format(str(target_file.udf["% Perfect Index Read"])))
+                            target_file.udf["Yield PF (Gb)"] = float(entry["Yield (Mbases)"].replace(",",""))/1000
+                            logging.info("{} Yield (Mbases)".format(str(target_file.udf["Yield PF (Gb)"])))
+                            target_file.udf["% Bases >=Q30"] = float(entry["% >= Q30bases"])
+                            logging.info("{}% Bases >=Q30".format(str(target_file.udf["% Bases >=Q30"])))
+                        except:
+                            sys.exit("Unable to set general artifact values")
+                        try:
+                            clusterType = None
+                            if "PF Clusters" in entry:
+                                clusterType = "PF Clusters"
+                            else:
+                                clusterType = "Clusters"
+                            #Paired runs are divided by two within flowcell parser
+                            if proc_stats["Paired"]:
+                                target_file.udf["# Reads"] = int(entry[clusterType].replace(",",""))*2
+                                target_file.udf["# Read Pairs"] = int(entry[clusterType].replace(",",""))
+                            #Since a single ended run has no pairs, pairs is set to equal reads
+                            else:
+                                target_file.udf["# Reads"] = int(entry[clusterType].replace(",",""))
+                                target_file.udf["# Read Pairs"] = int(entry[clusterType].replace(",",""))
+                            assign_lane_reads = assign_lane_reads + target_file.udf["# Reads"]
+                        except:
+                            sys.exit("Unable to set values for #Reads and #Read Pairs.")
+                        logging.info("{}# Reads".format(str(target_file.udf["# Reads"])))
+                        logging.info("{}# Reads Pairs".format(str(target_file.udf["# Read Pairs"])))
+                        
+                        try:
+                            if (demux_process.udf["Threshold for % bases >= Q30"] <= float(entry["% >= Q30bases"]) and 
+                            int(exp_smp_per_lne) <= target_file.udf["# Reads"] ):
+                                target_file.udf["Include reads"] = "YES"
+                                target_file.qc_flag = "PASSED"           
+                            else:
+                                target_file.udf["Include reads"] = "NO"
+                                target_file.qc_flag = "FAILED"
+                            logging.info("Q30 %: {}% found, minimum at {}%".format(str(float(entry["% >= Q30bases"])), str(demux_process.udf["Threshold for % bases >= Q30"])))
+                            logging.info("Expected reads: {} found, minimum at {}".format(str(target_file.udf["# Reads"]), str(int(exp_smp_per_lne)))) 
+                            logging.info("Sample QC status set to {}".format(target_file.qc_flag))
+                        except:
+                            sys.exit("Unable to set QC status for sample")
+                    #Counts undetermined per lane
+                    elif sample == "Undetermined":
+                        clusterType = None
+                        if "PF Clusters" in entry:
+                            clusterType = "PF Clusters"
+                        else:
+                            clusterType = "Clusters"
+                            
+                        if proc_stats["Paired"]:
+                            undet_lane_reads = int(entry[clusterType].replace(",",""))*2
+                            undet_read_pairs= int(entry[clusterType].replace(",",""))
+                        else:
+                            undet_lane_reads = int(entry[clusterType].replace(",",""))
+                            undet_read_pairs = int(entry[clusterType].replace(",",""))
+                        
+            try: 
+                target_file.put()
+            except:
+                sys.exit("Failed to apply artifact data to LIMS")
+            
+        #If undetermined reads are greater than threshold*reads_in_lane
+        found_undet = round(float(undet_lane_reads)/(assign_lane_reads+undet_lane_reads)*100, 2)
+        if  found_undet > demux_process.udf["Maximum % Undetermined Reads per Lane"]:
+            #This looks kind of bad in lims, but \n can't be used.
+            sys.stderr.write("WARNING: Undemultiplexed reads for lane {} was {} ({})% thus exceeding defined limit.\t".format(lane_no, undet_lane_reads, found_undet))
+        else:
+            logging.info("Found {} ({}%) undemultiplexed reads for lane {}.".format(undet_lane_reads, found_undet, lane_no))
+
+"""Creates demux_{FCID}.csv and attaches it to process"""
+def write_demuxfile(proc_stats, demux_id):
+    #Includes windows drive letter support
+    datafolder = "{}_data".format(proc_stats["Instrument"])
+    lanebc_path = os.path.join(os.sep,"srv","mfs", "taca_test",datafolder,proc_stats["Run ID"],"laneBarcode.html")
+    try:
+        laneBC = classes.LaneBarcodeParser(lanebc_path)
+    except:
+        sys.exit("Unable to fetch laneBarcode.html from {}".format(lanebc_path))
+    fname = "{}_demuxstats_{}.csv".format(demux_id, proc_stats["Flow Cell ID"])
+    
+    #Writes less undetermined info than undemultiplex_index.py. May cause problems downstreams
+    with open(fname, "w") as csvfile:
+        writer = csv.writer(csvfile)
+        writer.writerow(["Project", "Sample ID", "Lane", "# Reads", "Index","Index name", "% of >= Q30 Bases (PF)"])
+        for entry in laneBC.sample_data:
+            index_name = ""
+            if "PF Clusters" in entry:
+                reads = entry["PF Clusters"]
+            else: 
+                reads = entry["Clusters"]
+                
+            if proc_stats["Paired"]:
+                reads = int(reads.replace(",",""))*2
+            else:
+                reads = int(reads.replace(",","")) 
+            
+            try:
+                writer.writerow([entry["Project"],entry["Sample"],entry["Lane"],reads,entry["Barcode sequence"],index_name,entry["% >= Q30bases"]])
+            except:
+                sys.exit("Flowcell parser is unable to fetch all necessary fields for demux file.")
+    return laneBC.sample_data
+
+def converter(demux_process, epp_logger,demux_id):
+    
+    #Fetches info on "workflow" level
+    proc_stats = manipulate_workflow(demux_process)
+    #Sets up the process values
+    manipulate_process(demux_process, proc_stats)
+    #Create the demux output file
+    parser_struct = write_demuxfile(proc_stats, demux_id)
+    #Alters artifacts
+    set_sample_values(demux_process, parser_struct, proc_stats)
+    
+    #Changing log file name, can't do this step earlier since it breaks logging
+    for out in demux_process.all_outputs():
+        if out.name == "Script Log Details":
+            new_name = "{}_logfile_{}.txt".format(epp_logger.log_file, proc_stats["Flow Cell ID"])
+            move(epp_logger.log_file, new_name)
+
+@click.command()
+@click.option("--project_lims_id", required=True,help="Lims ID of project. Example:24-92373")
+@click.option("--demux_id", required=True,help="Id prefix for demux output.")
+@click.option("--log_id", required=True,help="Id prefix for logfile")
+def main(project_lims_id, demux_id, log_id ):
+    demux_process = Process(lims,id = project_lims_id)
+    #Sets up proper logging
+    with EppLogger(log_file=log_id, lims=lims, prepend=True) as epp_logger:
+        converter(demux_process, epp_logger, demux_id)      
+if __name__ == "__main__":
+    lims = Lims(BASEURI, USERNAME, PASSWORD)
+    lims.check_version()
+    main()

--- a/scripts/manage_demux_stats.py
+++ b/scripts/manage_demux_stats.py
@@ -15,7 +15,6 @@ Written by Isak Sylvin; isak.sylvin@scilifelab.se"""
 from genologics.lims import Lims
 from genologics.config import BASEURI, USERNAME, PASSWORD
 from genologics.entities import Process
-from genologics.epp import EppLogger
 import flowcell_parser.classes as classes
 from manage_demux_stats_thresholds import Thresholds
 

--- a/scripts/manage_demux_stats_thresholds.py
+++ b/scripts/manage_demux_stats_thresholds.py
@@ -11,7 +11,7 @@ class Thresholds():
         self.undet_indexes_perc = None
         
         #Checks that only supported values are entered
-        self.valid_instruments = ["miseq", "hiseq", "hiseqx"]
+        self.valid_instruments = ["miseq", "hiseq", "HiSeq_X"]
         self.valid_chemistry = ["MiSeq", "HiSeq Rapid Flow Cell v1","HiSeq Rapid Flow Cell v2", 
                              "TruSeq Rapid Flow Cell v2", "TruSeq Rapid Flow Cell v3", "HiSeq Flow Cell v4", "HiSeqX v2.5"]
         
@@ -66,7 +66,7 @@ class Thresholds():
                 if self.read_length >= 125:
                     self.Q30 = 80
                         
-        elif self.instrument == "hiseqx":
+        elif self.instrument == "HiSeq_X":
             if self.chemistry == "HiSeqX v2.5":
                 if self.read_length >= 150:
                     self.Q30 = 75
@@ -92,7 +92,7 @@ class Thresholds():
             #v4
             elif self.chemistry == "HiSeq Flow Cell v4":
                 self.exp_lane_clust = 188000000
-        elif self.instrument == "hiseqx":
+        elif self.instrument == "HiSeq_X":
             #HiSeqX runs are always paired!
             if self.paired:
                 #X v2.5 (common)

--- a/scripts/manage_demux_stats_thresholds.py
+++ b/scripts/manage_demux_stats_thresholds.py
@@ -78,7 +78,7 @@ class Thresholds():
     def set_exp_lane_clust(self):
         if self.instrument == "miseq":
             if self.chemistry == "MiSeq":
-                if self.read_length >= 75 and self.read_length <= 300:  
+                if self.read_length >= 76 and self.read_length <= 301:  
                     self.exp_lane_clust = 18000000
                 else:                               
                     self.exp_lane_clust = 10000000

--- a/scripts/manage_demux_stats_thresholds.py
+++ b/scripts/manage_demux_stats_thresholds.py
@@ -1,0 +1,96 @@
+"""Written by Isak Sylvin. isak.sylvin@scilifelab.se"""
+
+import sys
+
+class Thresholds():
+    def __init__(self, instrument, chemistry, paired, read_length):
+        self.Q30 = None
+        self.exp_lane_clust = None
+        self.undet_indexes_perc = None
+        
+        #Checks that only supported values are entered
+        self.valid_instruments = ["miseq", "hiseq", "hiseqx"]
+        self.valid_chemistry = ["MiSeq", "HiSeq Rapid Flow Cell v1","HiSeq Rapid Flow Cell v2", 
+                             "TruSeq Rapid Flow Cell v2", "TruSeq Rapid Flow Cell v3", "HiSeq Flow Cell v4", "HiSeqX v2.5"]
+        
+        if not instrument in self.valid_instruments or not chemistry in self.valid_chemistry:
+            sys.exit("Detected instrument, chemistry and/or read_setup are not classed as valid in bcl_thresholds.py")
+        else:
+            self.set_Q30(instrument, chemistry, read_length)
+            self.set_exp_lane_clust(instrument, chemistry, paired, read_length)
+            self.set_undet_indexes_perc()
+    
+    """Q30 values are derived from governing document 1244:4"""
+    def set_Q30(self, instrument, chemistry, read_length):
+        if instrument == "miseq":
+            if chemistry == "MiSeq":
+                if read_length >= 250:
+                    self.Q30 = 60
+                elif read_length >= 150:
+                    self.Q30 = 70
+                elif read_length >= 100:
+                    self.Q30 = 75
+                elif read_length < 100:
+                    self.Q30 = 80
+        elif instrument == "hiseq":
+            #Rapid run flowcell
+            if chemistry in ["HiSeq Rapid Flow Cell v1","HiSeq Rapid Flow Cell v2", "TruSeq Rapid Flow Cell v2", "TruSeq Rapid Flow Cell v1"] :
+                if read_length >= 150:
+                    self.Q30 = 75
+                elif read_length >= 100:
+                    self.Q30 = 80
+                elif read_length >= 50:
+                    self.Q30 = 85
+            #v3
+            elif chemistry == "HiSeq Flow Cell v3":
+                if read_length >= 100:
+                    self.Q30 = 80
+                elif read_length >= 50:
+                    self.Q30 = 85
+            #v4
+            elif chemistry == "HiSeq Flow Cell v4":
+                if read_length >= 125:
+                    self.Q30 = 80
+                        
+        elif instrument == "hiseqx":
+            if chemistry == "HiSeqX v2.5":
+                if read_length >= 150:
+                    self.Q30 = 75
+        if not self.Q30:
+            sys.exit("Can't set Q30. Detected setup is classed as valid but has no thresholds set in bcl_thresholds.py")
+    
+    """Expected lanes per cluster are derived from undemultiplex_index.py"""
+    def set_exp_lane_clust(self, instrument, chemistry, paired, read_length):
+        if instrument == "miseq":
+            if chemistry == "MiSeq":
+                if read_length >= 75 and read_length <= 300:  
+                    self.exp_lane_clust = 18000000
+                else:                               
+                    self.exp_lane_clust = 10000000
+        elif instrument == "hiseq":
+            #Rapid run flowcell
+            if chemistry in ["HiSeq Rapid Flow Cell v1","HiSeq Rapid Flow Cell v2", "TruSeq Rapid Flow Cell v2", "TruSeq Rapid Flow Cell v1"] :
+                self.exp_lane_clust = 114000000
+            #v3
+            elif chemistry == "HiSeq Flow Cell v3":
+               self.exp_lane_clust = 143000000
+            #v4
+            elif chemistry == "HiSeq Flow Cell v4":
+                self.exp_lane_clust = 188000000
+        elif instrument == "hiseqx":
+            #HiSeqX runs are always paired!
+            if paired:
+                #X v2.5 (common)
+                if chemistry == "HiSeqX v2.5":
+                    self.exp_lane_clust = 320000000
+                #X v2.0 (rare)
+                elif chemistry == "HiSeqX v2.0":
+                    self.exp_lane_clust = 305000000
+        if not self.exp_lane_clust:
+            sys.exit("Can't set Clusters per lane. Detected setup is classed as valid but has no thresholds set in bcl_thresholds.py")
+            
+    """Maximum undetermined per lane are derived from the current taca.yaml"""      
+    def set_undet_indexes_perc(self):
+        self.undet_indexes_perc = 5
+            
+            

--- a/scripts/manage_demux_stats_thresholds.py
+++ b/scripts/manage_demux_stats_thresholds.py
@@ -1,9 +1,11 @@
 """Written by Isak Sylvin. isak.sylvin@scilifelab.se"""
 
 import sys
+import logging
 
 class Thresholds():
     def __init__(self, instrument, chemistry, paired, read_length):
+        self.logger = logging.getLogger('demux_logger.thresholds')
         self.Q30 = None
         self.exp_lane_clust = None
         self.undet_indexes_perc = None
@@ -14,83 +16,101 @@ class Thresholds():
                              "TruSeq Rapid Flow Cell v2", "TruSeq Rapid Flow Cell v3", "HiSeq Flow Cell v4", "HiSeqX v2.5"]
         
         if not instrument in self.valid_instruments or not chemistry in self.valid_chemistry:
-            sys.exit("Detected instrument, chemistry and/or read_setup are not classed as valid in bcl_thresholds.py")
+            self.problem_handler("exit", "Detected instrument and chemistry combination are not classed as valid in manage_demux_stats_thresholds.py")
         else:
-            self.set_Q30(instrument, chemistry, read_length)
-            self.set_exp_lane_clust(instrument, chemistry, paired, read_length)
+            self.instrument = instrument
+            self.chemistry = chemistry
+            self.paired = paired
+            self.read_length = read_length
             self.set_undet_indexes_perc()
+        
+    def problem_handler(self, type, message):
+        if type == "exit":
+            self.logger.error(message)
+            sys.exit(message)
+        elif type == "warning":
+            self.logger.warning(message)
+            sys.stderr.write(message)
+        else:
+            self.logger.info(message)
     
     """Q30 values are derived from governing document 1244:4"""
-    def set_Q30(self, instrument, chemistry, read_length):
-        if instrument == "miseq":
-            if chemistry == "MiSeq":
-                if read_length >= 250:
+    def set_Q30(self):
+        if self.instrument == "miseq":
+            if self.chemistry == "MiSeq":
+                if self.read_length >= 250:
                     self.Q30 = 60
-                elif read_length >= 150:
+                elif self.read_length >= 150:
                     self.Q30 = 70
-                elif read_length >= 100:
+                elif self.read_length >= 100:
                     self.Q30 = 75
-                elif read_length < 100:
+                elif self.read_length < 100:
                     self.Q30 = 80
-        elif instrument == "hiseq":
+        elif self.instrument == "hiseq":
             #Rapid run flowcell
-            if chemistry in ["HiSeq Rapid Flow Cell v1","HiSeq Rapid Flow Cell v2", "TruSeq Rapid Flow Cell v2", "TruSeq Rapid Flow Cell v1"] :
-                if read_length >= 150:
+            if self.chemistry in ["HiSeq Rapid Flow Cell v1","HiSeq Rapid Flow Cell v2", "TruSeq Rapid Flow Cell v2", "TruSeq Rapid Flow Cell v1"] :
+                if self.read_length >= 150:
                     self.Q30 = 75
-                elif read_length >= 100:
+                elif self.read_length >= 100:
                     self.Q30 = 80
-                elif read_length >= 50:
+                elif self.read_length >= 50:
                     self.Q30 = 85
             #v3
-            elif chemistry == "HiSeq Flow Cell v3":
-                if read_length >= 100:
+            elif self.chemistry == "HiSeq Flow Cell v3":
+                if self.read_length >= 100:
                     self.Q30 = 80
-                elif read_length >= 50:
+                elif self.read_length >= 50:
                     self.Q30 = 85
             #v4
-            elif chemistry == "HiSeq Flow Cell v4":
-                if read_length >= 125:
+            elif self.chemistry == "HiSeq Flow Cell v4":
+                if self.read_length >= 125:
                     self.Q30 = 80
                         
-        elif instrument == "hiseqx":
-            if chemistry == "HiSeqX v2.5":
-                if read_length >= 150:
+        elif self.instrument == "hiseqx":
+            if self.chemistry == "HiSeqX v2.5":
+                if self.read_length >= 150:
                     self.Q30 = 75
         if not self.Q30:
-            sys.exit("Can't set Q30. Detected setup is classed as valid but has no thresholds set in bcl_thresholds.py")
+            self.problem_handler("exit", "Can't set Q30. No defined threshold. Chemistry: {}, Instrument: {}, Read Length: {}".\
+                                 format(self.instrument, self.chemistry, self.read_length))
     
     """Expected lanes per cluster are derived from undemultiplex_index.py"""
-    def set_exp_lane_clust(self, instrument, chemistry, paired, read_length):
-        if instrument == "miseq":
-            if chemistry == "MiSeq":
-                if read_length >= 75 and read_length <= 300:  
+    def set_exp_lane_clust(self):
+        if self.instrument == "miseq":
+            if self.chemistry == "MiSeq":
+                if self.read_length >= 75 and self.read_length <= 300:  
                     self.exp_lane_clust = 18000000
                 else:                               
                     self.exp_lane_clust = 10000000
-        elif instrument == "hiseq":
+        elif self.instrument == "hiseq":
             #Rapid run flowcell
-            if chemistry in ["HiSeq Rapid Flow Cell v1","HiSeq Rapid Flow Cell v2", "TruSeq Rapid Flow Cell v2", "TruSeq Rapid Flow Cell v1"] :
+            if self.chemistry in ["HiSeq Rapid Flow Cell v1","HiSeq Rapid Flow Cell v2", "TruSeq Rapid Flow Cell v2", "TruSeq Rapid Flow Cell v1"] :
                 self.exp_lane_clust = 114000000
             #v3
-            elif chemistry == "HiSeq Flow Cell v3":
+            elif self.chemistry == "HiSeq Flow Cell v3":
                self.exp_lane_clust = 143000000
             #v4
-            elif chemistry == "HiSeq Flow Cell v4":
+            elif self.chemistry == "HiSeq Flow Cell v4":
                 self.exp_lane_clust = 188000000
-        elif instrument == "hiseqx":
+        elif self.instrument == "hiseqx":
             #HiSeqX runs are always paired!
-            if paired:
+            if self.paired:
                 #X v2.5 (common)
-                if chemistry == "HiSeqX v2.5":
+                if self.chemistry == "HiSeqX v2.5":
                     self.exp_lane_clust = 320000000
                 #X v2.0 (rare)
-                elif chemistry == "HiSeqX v2.0":
+                elif self.chemistry == "HiSeqX v2.0":
                     self.exp_lane_clust = 305000000
+            else:
+                self.problem_handler("exit", "HiSeqX runs should always be paired but script has detected otherwise. Something has gone terribly wrong.")
         if not self.exp_lane_clust:
-            sys.exit("Can't set Clusters per lane. Detected setup is classed as valid but has no thresholds set in bcl_thresholds.py")
+            self.problem_handler("exit", "Can't set Clusters per lane. No defined threshold.Chemistry: {}, Instrument: {}, Read Length: {}".\
+                                 format(self.instrument, self.chemistry, self.read_length))
             
     """Maximum undetermined per lane are derived from the current taca.yaml"""      
     def set_undet_indexes_perc(self):
         self.undet_indexes_perc = 5
+    
+    
             
             


### PR DESCRIPTION
These scripts are meant to effectively replace undemultiplexed_index.py for the bcl conversion & demultiplexing step in the standard workflow for Miseq, Hiseq 2.5k & HiSeqX.

Code has been rewritten to be more accessible, and thresholds for automatic calculations have been seperated into another script for easier modification.

Scripts have also been validated and all that jazz, so it should be no collisions with merging them.
The undemultiplexed_index.py script is retained for rollback safety, but could arguably be removed at a later date.