### PR TITLE
Add warning when volume could not be fetched from previous steps

### DIFF
--- a/scripts/bravo_csv.py
+++ b/scripts/bravo_csv.py
@@ -114,7 +114,11 @@ def make_datastructure(currentStep, lims, log):
             elif obj['src_fc_id'] in samples_volumes:
                 obj['vol'] = samples_volumes[obj['src_fc_id']][obj['src_well']]
             else:
-                obj['vol'] = samples_volumes[obj['src_fc']][obj['src_well']]
+                try:
+                    obj['vol'] = samples_volumes[obj['src_fc']][obj['src_well']]
+                except KeyError:
+                    log.append("Unable to find previous volume for {}".format(obj["name"]))
+
             data.append(obj)
 
     return data

--- a/scripts/bravo_csv.py
+++ b/scripts/bravo_csv.py
@@ -117,6 +117,7 @@ def make_datastructure(currentStep, lims, log):
                 try:
                     obj['vol'] = samples_volumes[obj['src_fc']][obj['src_well']]
                 except KeyError:
+                    obj['vol'] = None
                     log.append("Unable to find previous volume for {}".format(obj["name"]))
 
             data.append(obj)


### PR DESCRIPTION
Previously no information was given when data for a sample could not be found and you would pontentially miss when a transfer was excluded.