### PR TITLE
Cluster count bug

### DIFF
--- a/scripts/manage_demux_stats.py
+++ b/scripts/manage_demux_stats.py
@@ -281,16 +281,18 @@ def set_sample_values(demux_process, parser_struct, proc_stats):
                                 basenumber = int(entry[clusterType].replace(",",""))
                                 if proc_stats["Paired"]:
                                     #Undet always 0 unless manually included
-                				    samplesum[sample]["# Reads"] = basenumber*2 + undet_reads if not "# Reads" in samplesum[sample] \
-                                    else samplesum[sample]["# Reads"] + basenumber*2 + undet_reads 
-                				    samplesum[sample]["# Read Pairs"] = basenumber + undet_reads/2 if not "# Read Pairs" in samplesum[sample] \
-                				    else samplesum[sample]["# Read Pairs"] + basenumber + undet_reads/2
+                                    samplesum[sample]["# Reads"] = basenumber*2 + undet_reads if not "# Reads" in samplesum[sample] \
+                                    else samplesum[sample]["# Reads"] + basenumber*2 + undet_reads
+                                    
+                                    samplesum[sample]["# Read Pairs"] = basenumber + undet_reads/2 if not "# Read Pairs" in samplesum[sample] \
+                                    else samplesum[sample]["# Read Pairs"] + basenumber + undet_reads/2
                                 #Since a single ended run has no pairs, pairs is set to equal reads
                                 else:
                                     #Undet always 0 unless manually included
-                				    samplesum[sample]["# Reads"] = basenumber + undet_reads if not "# Reads" in samplesum[sample] \
-                				    else samplesum[sample]["# Reads"] + basenumber + undet_reads
-                				    samplesum[sample]["# Read Pairs"] = samplesum[sample]["# Reads"] if not "# Read Pairs" in samplesum[sample] \
+                                    samplesum[sample]["# Reads"] = basenumber + undet_reads if not "# Reads" in samplesum[sample] \
+                                    else samplesum[sample]["# Reads"] + basenumber + undet_reads
+                                    
+                                    samplesum[sample]["# Read Pairs"] = samplesum[sample]["# Reads"] if not "# Read Pairs" in samplesum[sample] \
                                     else samplesum[sample]["# Read Pairs"] + samplesum[sample]["# Reads"]
 			    except Exception as e:
                                 problem_handler("exit", "Unable to set values for #Reads and #Read Pairs: {}".format(e.message))

--- a/scripts/manage_demux_stats.py
+++ b/scripts/manage_demux_stats.py
@@ -259,10 +259,10 @@ def set_sample_values(demux_process, parser_struct, proc_stats):
                                     #If reads in seq step, and the lane is equal to the current lane
                                     if inp.location[1][0] == lane_no and "Clusters PF R1" in inp.udf:
                                         if proc_stats["Paired"]:
-                                            target_file.udf["# Reads"] = inp.udf["Clusters PF R1"]
+                                            target_file.udf["# Reads"] = inp.udf["Clusters PF R1"]*2
                                             target_file.udf["# Read Pairs"] = target_file.udf["# Reads"]/2
                                         else:
-                                            target_file.udf["# Reads"] = inp.udf["Clusters PF R1"]*2
+                                            target_file.udf["# Reads"] = inp.udf["Clusters PF R1"]
                                             target_file.udf["# Read Pairs"] = target_file.udf["# Reads"]/2
                                 logger.info("{}# Reads".format(target_file.udf["# Reads"]))
                                 logger.info("{}# Read Pairs".format(target_file.udf["# Read Pairs"]))
@@ -281,17 +281,17 @@ def set_sample_values(demux_process, parser_struct, proc_stats):
                                 basenumber = int(entry[clusterType].replace(",",""))
                                 if proc_stats["Paired"]:
                                     #Undet always 0 unless manually included
-				    samplesum[sample]["# Reads"] = basenumber*2 + undet_reads if not "# Reads" in samplesum[sample] \
+                				    samplesum[sample]["# Reads"] = basenumber*2 + undet_reads if not "# Reads" in samplesum[sample] \
                                     else samplesum[sample]["# Reads"] + basenumber*2 + undet_reads 
-				    samplesum[sample]["# Read Pairs"] = basenumber + undet_reads/2 if not "# Read Pairs" in samplesum[sample] \
-				    else samplesum[sample]["# Read Pairs"] + basenumber + undet_reads/2
+                				    samplesum[sample]["# Read Pairs"] = basenumber + undet_reads/2 if not "# Read Pairs" in samplesum[sample] \
+                				    else samplesum[sample]["# Read Pairs"] + basenumber + undet_reads/2
                                 #Since a single ended run has no pairs, pairs is set to equal reads
                                 else:
                                     #Undet always 0 unless manually included
-				    samplesum[sample]["# Reads"] = basenumber + undet_reads if not "# Reads" in samplesum[sample] \
-				    else samplesum[sample]["# Reads"] + basenumber + undet_reads
-				    samplesum[sample]["# Read Pairs"] = samplesum[sample]["# Reads"] if not "# Read Pairs" in samplesum[sample] \
-			            else samplesum[sample]["# Read Pairs"] + samplesum[sample]["# Reads"]
+                				    samplesum[sample]["# Reads"] = basenumber + undet_reads if not "# Reads" in samplesum[sample] \
+                				    else samplesum[sample]["# Reads"] + basenumber + undet_reads
+                				    samplesum[sample]["# Read Pairs"] = samplesum[sample]["# Reads"] if not "# Read Pairs" in samplesum[sample] \
+                                    else samplesum[sample]["# Read Pairs"] + samplesum[sample]["# Reads"]
 			    except Exception as e:
                                 problem_handler("exit", "Unable to set values for #Reads and #Read Pairs: {}".format(e.message))
 

--- a/scripts/manage_demux_stats.py
+++ b/scripts/manage_demux_stats.py
@@ -263,7 +263,7 @@ def set_sample_values(demux_process, parser_struct, proc_stats):
                                             target_file.udf["# Read Pairs"] = target_file.udf["# Reads"]/2
                                         else:
                                             target_file.udf["# Reads"] = inp.udf["Clusters PF R1"]
-                                            target_file.udf["# Read Pairs"] = target_file.udf["# Reads"]/2
+                                            target_file.udf["# Read Pairs"] = target_file.udf["# Reads"]
                                 logger.info("{}# Reads".format(target_file.udf["# Reads"]))
                                 logger.info("{}# Read Pairs".format(target_file.udf["# Read Pairs"]))
 


### PR DESCRIPTION
For single ended noindex runs the amount of clusters were incorrectly multiplied.
Most likely uncaught for so long since the circumstances are quite rare.
Also cleaned up some weird indentation.