### PR TITLE
allow for shorter read lengths

### DIFF
--- a/scripts/manage_demux_stats_thresholds.py
+++ b/scripts/manage_demux_stats_thresholds.py
@@ -53,7 +53,7 @@ class Thresholds():
                     self.Q30 = 75
                 elif self.read_length >= 100:
                     self.Q30 = 80
-                elif self.read_length >= 50:
+                elif self.read_length < 100:
                     self.Q30 = 85
             #v3
             elif self.chemistry == "HiSeq Flow Cell v3":


### PR DESCRIPTION
We currently have a project with 21bp for Hiseq Rapid run. This was not allowed. 