### PR TITLE
Prevent commas from platenames in worklist

### DIFF
--- a/VERSIONLOG.md
+++ b/VERSIONLOG.md
@@ -1,5 +1,8 @@
 # Scilifelab_epps Version Log
 
+## 20221215.1
+When writing the Zika deck layout in a worklist comment, omit all commas, to prevent the line from being cut-off.
+
 ## 20221121.1
 Large update in functionality of Zika code. Accomodate two new UDFs and enable usage in the non-validated methods SMARTer PicoRNA, QIAseq miRNA and amplicon normalization.
 

--- a/scripts/bravo_csv.py
+++ b/scripts/bravo_csv.py
@@ -421,7 +421,7 @@ def zika_wl(df, zika_max_vol, file_meta, pool_info):
 
             if i != 1:
                 csvContext.write("PAUSE, 0\n")
-            csvContext.write("COMMENT, Set up layout {}:    ".format(i) + "     ".join(deck.src_fc) + "\n")
+            csvContext.write("COMMENT, Set up layout {}:    ".format(i) + "     ".join(deck.src_fc.str.replace(",","")) + "\n")
 
             # Write sample transfers
             wl_current = wl_sample[wl_sample.layout == i]

--- a/scripts/zika.py
+++ b/scripts/zika.py
@@ -366,11 +366,12 @@ def write_worklist(df, deck, wl_filename, comments=None, multi_aspirate=False):
 
 
 def get_deck_comment(deck):
-    """Convert the plate:position 'decktionary' into a worklist comment."""
+    """ Convert the plate:position 'decktionary' into a worklist comment
+    """
 
     pos2plate = dict([(pos, plate) for plate, pos in deck.items()])
 
-    l = [pos2plate[i] if i in pos2plate else "[Empty]" for i in range(1, 6)]
+    l = [pos2plate[i].replace(",", "") if i in pos2plate else "[Empty]" for i in range(1, 6)]
 
     deck_comment = "COMMENT, Set up layout:    " + "     ".join(l) + "\n"
 


### PR DESCRIPTION
Currently, including plate names with commas will cause the comment line in the worklist explaining the plate layout to be cut off.

It will also look weird when opening the worklist file in any comma-separating viewing software.

This is fixed by replacing all commas in the plate names with an empty string prior to writing it to the worklist file.

The change is small enough not to warrant a validation.