### PR TITLE
Differentiate Zika normalization parameters for Amplicon

### DIFF
--- a/VERSIONLOG.md
+++ b/VERSIONLOG.md
@@ -1,5 +1,8 @@
 # Scilifelab_epps Version Log
 
+## 20230213.1
+Differentiate Zika normalization parameters for Amplicon workflow plate set-up. Unlike QIAseq and SMARTer it should use customer metrics and a lower minimum volume.
+
 ## 20230207.1
 Update 20230130.2, correct the volume and conc information that is fetched and support both nM and ng/ul pooling. General updates to make the code simpler and more maintainable.
 

--- a/scripts/bravo_csv.py
+++ b/scripts/bravo_csv.py
@@ -681,18 +681,21 @@ def default_bravo(lims, currentStep, with_total_vol=True):
         targets = [
             ('SMARTer Pico RNA', "Setup Workset/Plate"),
             ("QIAseq miRNA",     "Setup Workset/Plate"),
-            ("Amplicon",         "Setup Workset/Plate")
         ]
         ):
         zika_methods.norm(
             currentStep=currentStep, 
+            lims=lims
+            )
+    elif zika.verify_step(
+        currentStep,
+        targets = [("Amplicon", "Setup Workset/Plate")]
+        ):
+        zika_methods.norm(
+            currentStep=currentStep, 
             lims=lims, 
-            buffer_strategy="first_column",
-            volume_expansion=True,
-            multi_aspirate=True,
+            # Use lower minimum pipetting volume and customer metrics
             zika_min_vol=0.1,
-            well_dead_vol=5,
-            well_max_vol=15,
             use_customer_metrics=True
             )
 


### PR DESCRIPTION
Differentiate Zika normalization parameters for Amplicon workflow plate set-up. Unlike QIAseq and SMARTer it should use customer metrics and a lower minimum volume.