### PR TITLE
Zika bugfix split transfers

### DIFF
--- a/VERSIONLOG.md
+++ b/VERSIONLOG.md
@@ -1,5 +1,8 @@
 # Scilifelab_epps Version Log
 
+## 20230613.1
+Rework zika_utils.format_worklist() split transfers logic to prevent the post-split volume from ending up as less than what is allowed by the instrument.
+
 ## 20230602.1
 Rename utils module to epp_utils to avoid name collision with native Python module and fix bug causing fatal error for Zika pooling.
 


### PR DESCRIPTION
This script has had different rationales over time for splitting larger transfer volumes into smaller transfer volumes, to accommodate the Zika hardware constraint of >100 and <5000 nl.

The versions would have done the following with a transfer of `15002` nl:

**Old code (initial validation):**
`3751 + 3751 + 3751`
--> Ugly

Re-vamped code (current):
`5000 + 5000 + 2`
--> Will not be accepted by instrument

New code (this PR):
`5000 + 2501 + 2501`
--> Will use 5000 nl transfers UP UNTIL last pair, which will be split evenly.

Successfully tested on Stage.
