### PR TITLE
Bugfix "ONT process stared runs" DB update

### DIFF
--- a/VERSIONLOG.md
+++ b/VERSIONLOG.md
@@ -1,5 +1,8 @@
 # Scilifelab_epps Version Log
 
+## 20230925.1
+Bugfix ONT process started runs
+
 ## 20230914.1
 Replace mfs with ngi-nas-ns
 

--- a/scripts/ont_send_loading_info_to_db.py
+++ b/scripts/ont_send_loading_info_to_db.py
@@ -69,7 +69,6 @@ def match_to_db_using_run_id(lims, args):
                 "step_name": currentStep.type.name,
                 "pid": currentStep.id,
                 "timestamp": timestamp,
-                "qc": art.udf["ONT flow cell QC pore count"],
                 "load_fmol": art.udf["ONT flow cell loading amount (fmol)"],
             }
 


### PR DESCRIPTION
The flow cell QC is now automated from the instrument, so the EPP shouldn't try to pull it from LIMS.