### PR TITLE
Hotfix, fix import syntax

### DIFF
--- a/scripts/zika_methods.py
+++ b/scripts/zika_methods.py
@@ -6,7 +6,7 @@ This module contains methods for normalization and pooling on the Mosquito Zika 
 Written by Alfred Kedhammar
 """
 
-from scripts import zika_utils
+import zika_utils
 import pandas as pd
 import sys
 import numpy as np


### PR DESCRIPTION
I though scripts was a module but the files there-in are actually available as a direct import due to setup-tools configuration. Oops :(