### PR TITLE
Try improving VERSIONLOG.md check

### DIFF
--- a/.github/workflows/check-log.yml
+++ b/.github/workflows/check-log.yml
@@ -12,12 +12,8 @@ jobs:
 
       - name: Check for VERSIONLOG.MD changes
         id: versionlog_check
-        # 1) Find the common ancestor between the current HEAD and the base branch
-        # 2) Then see if the versionlog has been updated in the PR since it diverged
-        #    from the common ancestor
         run: |
-          PR_BASE_SHA=$(git merge-base HEAD ${{ github.event.pull_request.base.sha }})
-          FILE_CHANGED=$(git diff --name-only $PR_BASE_SHA HEAD | grep 'VERSIONLOG.md' || true)
+          FILE_CHANGED=$(git diff --name-only ${{ github.event.pull_request.base.sha }} HEAD | grep 'VERSIONLOG.md' || true)
           if [ -n "$FILE_CHANGED" ]; then
             echo "VERSIONLOG.MD has been changed."
           else

--- a/VERSIONLOG.md
+++ b/VERSIONLOG.md
@@ -1,5 +1,9 @@
 # Scilifelab_epps Version Log
 
+## 20240422.2
+
+Update GHA script to check VERSIONLOG.md diff to compare the latest PR-commit to the latest upstream/master commit instead of the commit at the base of the PR-branch.
+
 ## 20240422.1
 
 Fix bug that seq_platform cannot be fetched when sample ID is in a wrong format


### PR DESCRIPTION
Current version compares latest commit of the PR branch to the base of the PR-branch.

We instead want to compare it to the commit we are merging the PR into.