### PR TITLE
Include Project name and sequencing setup in AVITI run manifest

### DIFF
--- a/VERSIONLOG.md
+++ b/VERSIONLOG.md
@@ -1,5 +1,9 @@
 # Scilifelab_epps Version Log
 
+## 20240902.3
+
+Include Project name and sequencing setup in AVITI run manifest
+
 ## 20240902.2
 
 Ruff format

--- a/scripts/generate_aviti_run_manifest.py
+++ b/scripts/generate_aviti_run_manifest.py
@@ -122,11 +122,21 @@ def get_samples_section(process: Process) -> str:
                 index1 = label_seq
                 index2 = ""
 
+            # Project name and sequencing setup
+            if sample.project:
+                project = sample.project.name
+                seq_setup = sample.project.udf.get("Sequencing setup", "0-0")
+            else:
+                project = ""
+                seq_setup = "0-0"
+
             row = {}
             row["SampleName"] = sample.name
             row["Index1"] = index1
             row["Index2"] = index2
             row["Lane"] = lane
+            row["Project"] = project
+            row["Recipe"] = seq_setup
 
             lane_rows.append(row)
 


### PR DESCRIPTION
Sample-level fields added in AVITI `RunManifest.csv` so that we can re-use the logics for demux for Illumina runs.