### PR TITLE
Improve manifest generation

### DIFF
--- a/VERSIONLOG.md
+++ b/VERSIONLOG.md
@@ -1,5 +1,9 @@
 # Scilifelab_epps Version Log
 
+## 20241009.1
+
+Improve AVITI run manifest generation with sample-level settings. No longer produce submanifests.
+
 ## 20241006.2
 
 Improve aviti run parameter parser

--- a/scripts/generate_aviti_run_manifest.py
+++ b/scripts/generate_aviti_run_manifest.py
@@ -319,9 +319,7 @@ def make_manifest(
         df["Index1"] = df["Index1"].apply(lambda x: x[:min_idx1_len])
         df["Index2"] = df["Index2"].apply(lambda x: x[:min_idx2_len])
 
-        samples_section = (
-            f"[SAMPLES]\n{df.iloc[:, 0:6].to_csv(index=None, header=True)}"
-        )
+        samples_section = f"[SAMPLES]\n{df.to_csv(index=None, header=True)}"
 
     elif manifest_type == "empty":
         samples_section = ""

--- a/scripts/generate_aviti_run_manifest.py
+++ b/scripts/generate_aviti_run_manifest.py
@@ -277,27 +277,11 @@ def make_manifest(
     manifest_root_name: str,
     manifest_type: str,
 ) -> tuple[str, str]:
-    df = df_samples_and_controls.copy()
+    # Make copy not to mess up input dataframe
+    df_copy = df_samples_and_controls.copy()
 
-    file_name = f"{manifest_root_name}_{manifest_type}.csv"
-    runValues_section = "\n".join(
-        [
-            "[RUNVALUES]",
-            "KeyName, Value",
-            f'lims_step_name, "{process.type.name}"',
-            f'lims_step_id, "{process.id}"',
-            f'manifest_file, "{file_name}"',
-        ]
-    )
-
-    settings_section = "\n".join(
-        [
-            "[SETTINGS]",
-            "SettingName, Value",
-        ]
-    )
-
-    df_subset_cols = df[
+    # Subset columns
+    df = df_copy[
         [
             "SampleName",
             "Index1",
@@ -311,8 +295,26 @@ def make_manifest(
         ]
     ]
 
+    file_name = f"{manifest_root_name}_{manifest_type}.csv"
+    runValues_section = "\n".join(
+        [
+            "[RUNVALUES]",
+            "KeyName, Value",
+            f"lims_step_name, {process.type.name}",
+            f"lims_step_id, {process.id}",
+            f"manifest_file, {file_name}",
+        ]
+    )
+
+    settings_section = "\n".join(
+        [
+            "[SETTINGS]",
+            "SettingName, Value",
+        ]
+    )
+
     if manifest_type == "untrimmed":
-        samples_section = f"[SAMPLES]\n{df_subset_cols.to_csv(index=None, header=True)}"
+        samples_section = f"[SAMPLES]\n{df.to_csv(index=None, header=True)}"
 
     elif manifest_type == "trimmed":
         min_idx1_len = df["Index1"].apply(len).min()

--- a/scripts/generate_aviti_run_manifest.py
+++ b/scripts/generate_aviti_run_manifest.py
@@ -286,7 +286,6 @@ def make_manifest(
             "Lane",
             "Project",
             "Recipe",
-            "phix_loaded",
             "lims_label",
             "settings",
         ]

--- a/scripts/generate_aviti_run_manifest.py
+++ b/scripts/generate_aviti_run_manifest.py
@@ -277,11 +277,8 @@ def make_manifest(
     manifest_root_name: str,
     manifest_type: str,
 ) -> tuple[str, str]:
-    # Make copy not to mess up input dataframe
-    df_copy = df_samples_and_controls.copy()
-
-    # Subset columns
-    df = df_copy[
+    # Make copy of input df and subset columns to include in manifest
+    df = df_samples_and_controls[
         [
             "SampleName",
             "Index1",
@@ -293,7 +290,7 @@ def make_manifest(
             "lims_label",
             "settings",
         ]
-    ]
+    ].copy()
 
     file_name = f"{manifest_root_name}_{manifest_type}.csv"
     runValues_section = "\n".join(


### PR DESCRIPTION
- Don't create submanifests, leave it to TACA
- Create new manifest column `settings` to contain sample level settings to be implemented by TACA
- Use sample level settings to handle I1 fastq for 10X 8bp single idxs
- General improvements in factoring and readability