### PR TITLE
Workaround for JSON serialization of incompatible LIMS UDF values

### DIFF
--- a/VERSIONLOG.md
+++ b/VERSIONLOG.md
@@ -1,5 +1,9 @@
 # Scilifelab_epps Version Log
 
+## 20250723.2
+
+Fix error trying to run json.dumps() on UDF dictionaries whose values are non-JSON-serializable by introducing custom encoder.
+
 ## 20250723.1
 
 Enable Zika for applications generic process.

--- a/scilifelab_epps/utils/udf_tools.py
+++ b/scilifelab_epps/utils/udf_tools.py
@@ -1,3 +1,4 @@
+import datetime
 import json
 import logging
 import xml.etree.ElementTree as ET
@@ -146,6 +147,19 @@ def list_udfs(art: Artifact) -> list:
     return [item_tuple[0] for item_tuple in art.udf.items()]
 
 
+class CustomJSONEncoder(json.JSONEncoder):
+    """This class handles serialization of non-JSON-serializable
+    objects that can be encountered in LIMS.
+    """
+
+    def default(self, obj):
+        if isinstance(obj, datetime.datetime) or isinstance(obj, datetime.date):
+            return obj.isoformat()
+        elif isinstance(obj, set):
+            return list(obj)
+        return super().default(obj)
+
+
 def fetch_last(
     target_art: Artifact,
     target_udfs: str | list,
@@ -219,7 +233,7 @@ def fetch_last(
                     else:
                         if log_traceback is True:
                             logging.info(
-                                f"Traceback:\n{json.dumps(traceback, indent=2)}"
+                                f"Traceback:\n{json.dumps(traceback, indent=2, cls=CustomJSONEncoder)}"
                             )
                         logging.info(
                             f"Found target UDF '{target_udf}'"


### PR DESCRIPTION
Basically, when we added a date UDF for the flowcell reception, we ran into issues for the "ONT: Calculate Volumes" EPP because it delves into the artifact lineage recursively and serializes the UDF dicts of the candidate artifacts into json, which is incompatible for the Python date type.

This PR fixes the issue by introducing a custom encoder, serializing date objects as their ISO-formatted string.