### PR TITLE
Add ONT barcode support across scripts

### DIFF
--- a/VERSIONLOG.md
+++ b/VERSIONLOG.md
@@ -1,5 +1,9 @@
 # Scilifelab_epps Version Log
 
+## 20260527.1
+
+Add comprehensive ONT barcode support across scripts
+
 ## 20260521.1
 
 Add NextSeq Load to Flowcell to runningnotes_from_sequencing

--- a/data/ONT_barcodes.py
+++ b/data/ONT_barcodes.py
@@ -645,3 +645,47 @@ for lims_kit, labels in lims_kits2labels.items():
         )
 
         ont_label2dict[label] = label_dict
+
+
+# Build a reverse mapping from sequence to barcode info (for lookup by sequence)
+ont_seq2label: dict[str, dict] = {}
+for label, label_dict in ont_label2dict.items():
+    seq = label_dict["seq"]
+    # Store the barcode info keyed by sequence
+    # If multiple labels have the same sequence, keep the first one encountered
+    if seq not in ont_seq2label:
+        ont_seq2label[seq] = label_dict
+
+
+def get_barcode_info(barcode_value: str) -> dict:
+    """Get barcode info from label, sequence, or barcode name.
+
+    Handles multiple formats:
+    - Full label: "01_A1_NB01 (CACAAAGACACCGACAACTTTCTT)"
+    - Sequence only: "CACAAAGACACCGACAACTTTCTT"
+    - Barcode name: "NB01", "BC15", "16S15", etc.
+    - Partial label: "01_A1_NB01"
+    """
+    # Try as full label first
+    if barcode_value in ont_label2dict:
+        return ont_label2dict[barcode_value]
+
+    # Try as sequence
+    if barcode_value in ont_seq2label:
+        return ont_seq2label[barcode_value]
+
+    # Try to extract barcode name from partial label
+    # E.g., "01_A1_NB01" -> "NB01", or "01_A1_NB01 (seq)" -> "NB01"
+    barcode_name = barcode_value.split("_")[-1].split(" ")[0]
+
+    # Try as barcode name (e.g., "NB01", "BC15")
+    if barcode_name in ont_name2seq:
+        seq = ont_name2seq[barcode_name]
+        if seq in ont_seq2label:
+            return ont_seq2label[seq]
+
+    # If still not found, raise KeyError with helpful message
+    raise KeyError(
+        f"Barcode '{barcode_value}' not found in available barcodes. "
+        f"Expected one of: full label '01_A1_NB01 (...)', sequence, or barcode name 'NB01'."
+    )

--- a/scripts/generate_minknow_samplesheet.py
+++ b/scripts/generate_minknow_samplesheet.py
@@ -13,7 +13,7 @@ from genologics.entities import Artifact, Process
 from genologics.lims import Lims
 from tabulate import tabulate
 
-from data.ONT_barcodes import ont_label2dict
+from data.ONT_barcodes import get_barcode_info
 from scilifelab_epps.epp import get_pool_sample_label_mapping, upload_file
 from scilifelab_epps.wrapper import epp_decorator
 
@@ -210,12 +210,10 @@ def generate_MinKNOW_samplesheet(process):
                     "Positions must be unassigned for non-PromethION flow cells."
                 )
 
-            # 1) Barcodes implied from kit selection, kit ends with '24' or '96'
-            if lims_kit[-2:] in ["24", "96"]:
-                # Assert barcodes are found within library
-                assert ont_barcodes, (
-                    f"ONT barcodes are implied from kit selection, but no ONT barcodes were found within library {ont_library.name}"
-                )
+            # Process barcodes if present in the library
+            if ont_barcodes:
+                # If kit name suggests barcodes (ends with 24/96), this is expected
+                # If not, barcodes can still be present from manual barcode preparation
 
                 # Append rows for each barcode
                 alias_column_name = "sample_name"
@@ -228,7 +226,7 @@ def generate_MinKNOW_samplesheet(process):
 
                 for barcode_row_data in barcode_rows_data:
                     row["alias"] = sanitize_string(barcode_row_data[alias_column_name])
-                    barcode_id = ont_label2dict[barcode_row_data["ont_barcode"]]["num"]
+                    barcode_id = get_barcode_info(barcode_row_data["ont_barcode"])["num"]
                     row["barcode"] = f"barcode{str(barcode_id).zfill(2)}"
 
                     assert re.match(r"barcode\d{2}", row["barcode"])
@@ -236,11 +234,11 @@ def generate_MinKNOW_samplesheet(process):
 
                     rows.append(row.copy())
 
-            # 2) No barcodes implied from kit selection
             else:
-                # Assert barcodes are not found within library
-                assert not ont_barcodes, (
-                    f"Library '{ont_library.name}' appears to contain ONT barcodes, but no ONT barcodes are implied from the kit selection."
+                # No barcodes in library
+                # Assert that kit selection doesn't suggest barcodes either
+                assert lims_kit[-2:] not in ["24", "96"], (
+                    f"ONT barcodes are implied from kit selection, but no ONT barcodes were found within library {ont_library.name}"
                 )
 
                 # Append single row

--- a/scripts/generate_minknow_samplesheet.py
+++ b/scripts/generate_minknow_samplesheet.py
@@ -226,7 +226,9 @@ def generate_MinKNOW_samplesheet(process):
 
                 for barcode_row_data in barcode_rows_data:
                     row["alias"] = sanitize_string(barcode_row_data[alias_column_name])
-                    barcode_id = get_barcode_info(barcode_row_data["ont_barcode"])["num"]
+                    barcode_id = get_barcode_info(barcode_row_data["ont_barcode"])[
+                        "num"
+                    ]
                     row["barcode"] = f"barcode{str(barcode_id).zfill(2)}"
 
                     assert re.match(r"barcode\d{2}", row["barcode"])

--- a/scripts/index_distance_checker.py
+++ b/scripts/index_distance_checker.py
@@ -12,7 +12,7 @@ from genologics.entities import Process
 from genologics.lims import Lims
 
 from data.Chromium_10X_indexes import Chromium_10X_indexes
-from data.ONT_barcodes import ont_name2seq, get_barcode_info
+from data.ONT_barcodes import get_barcode_info
 from scilifelab_epps.epp import attach_file
 
 SMARTSEQ3_indexes_json = (

--- a/scripts/index_distance_checker.py
+++ b/scripts/index_distance_checker.py
@@ -12,6 +12,7 @@ from genologics.entities import Process
 from genologics.lims import Lims
 
 from data.Chromium_10X_indexes import Chromium_10X_indexes
+from data.ONT_barcodes import ont_name2seq, get_barcode_info
 from scilifelab_epps.epp import attach_file
 
 SMARTSEQ3_indexes_json = (
@@ -34,6 +35,7 @@ VALIDBASES_PAT = re.compile(r"^[ATCGN\-]+$")
 TENX_SINGLE_PAT = re.compile("SI-(?:GA|NA)-[A-H][1-9][0-2]?")
 TENX_DUAL_PAT = re.compile("SI-(?:TT|NT|NN|TN|TS)-[A-H][1-9][0-2]?")
 SMARTSEQ_PAT = re.compile("SMARTSEQ[1-9]?-[1-9][0-9]?[A-P]")
+ONT_PAT = re.compile(r"^(?:NB|BC|RB|BP|RLB|16S)\d{1,2}[A-Z]?$")  # Matches NB01, BC15, RB01, 16S05, etc.
 NGISAMPLE_PAT = re.compile("P[0-9]+_[0-9]+")
 
 
@@ -311,6 +313,30 @@ def prepare_index_table(process):
                                     sp_obj_sub["idx1"] = i7_idx
                                     sp_obj_sub["idx2"] = i5_idx
                                     data.append(sp_obj_sub)
+                        elif ONT_PAT.findall(idxs[0]):
+                            # ONT barcode - look up sequence from ONT_barcodes.py
+                            ont_barcode_name = ONT_PAT.findall(idxs[0])[0]
+                            try:
+                                barcode_info = get_barcode_info(ont_barcode_name)
+                                sp_obj["pool"] = pool_name
+                                sp_obj["proj_id"] = proj_id
+                                sp_obj["sn"] = sample.name.replace(",", "")
+                                sp_obj["idx_name"] = ont_barcode_name
+                                sp_obj["idx1"] = barcode_info["seq"]
+                                sp_obj["idx2"] = ""
+                                data.append(sp_obj)
+                            except KeyError:
+                                # Barcode not found in ONT database
+                                message.append(
+                                    f"ONT barcode '{ont_barcode_name}' not found in barcode database for sample {sample.name}"
+                                )
+                                sp_obj["pool"] = pool_name
+                                sp_obj["proj_id"] = proj_id
+                                sp_obj["sn"] = sample.name.replace(",", "")
+                                sp_obj["idx_name"] = ont_barcode_name
+                                sp_obj["idx1"] = ""
+                                sp_obj["idx2"] = ""
+                                data.append(sp_obj)
                         else:
                             sp_obj["pool"] = pool_name
                             sp_obj["proj_id"] = proj_id
@@ -368,6 +394,7 @@ def find_barcode(sample_idxs, sample, process):
                                         or TENX_SINGLE_PAT.findall(reagent_label_name)
                                         or TENX_DUAL_PAT.findall(reagent_label_name)
                                         or SMARTSEQ_PAT.findall(reagent_label_name)
+                                        or ONT_PAT.findall(reagent_label_name)
                                     )
                                 )
                             ):
@@ -380,6 +407,7 @@ def find_barcode(sample_idxs, sample, process):
                     TENX_SINGLE_PAT.findall(reagent_label_name)
                     or TENX_DUAL_PAT.findall(reagent_label_name)
                     or SMARTSEQ_PAT.findall(reagent_label_name)
+                    or ONT_PAT.findall(reagent_label_name)
                 )
                 if idxs:
                     # Put in tuple with empty string as second index to

--- a/scripts/index_distance_checker.py
+++ b/scripts/index_distance_checker.py
@@ -35,7 +35,9 @@ VALIDBASES_PAT = re.compile(r"^[ATCGN\-]+$")
 TENX_SINGLE_PAT = re.compile("SI-(?:GA|NA)-[A-H][1-9][0-2]?")
 TENX_DUAL_PAT = re.compile("SI-(?:TT|NT|NN|TN|TS)-[A-H][1-9][0-2]?")
 SMARTSEQ_PAT = re.compile("SMARTSEQ[1-9]?-[1-9][0-9]?[A-P]")
-ONT_PAT = re.compile(r"^(?:NB|BC|RB|BP|RLB|16S)\d{1,2}[A-Z]?$")  # Matches NB01, BC15, RB01, 16S05, etc.
+ONT_PAT = re.compile(
+    r"^(?:NB|BC|RB|BP|RLB|16S)\d{1,2}[A-Z]?$"
+)  # Matches NB01, BC15, RB01, 16S05, etc.
 NGISAMPLE_PAT = re.compile("P[0-9]+_[0-9]+")
 
 

--- a/scripts/index_distance_checker.py
+++ b/scripts/index_distance_checker.py
@@ -331,7 +331,7 @@ def prepare_index_table(process):
                                     f"ONT barcode '{ont_barcode_name}' not found in barcode database for sample {sample.name}"
                                 )
                                 sp_obj["idx1"] = ""
-                            
+
                             sp_obj["idx2"] = ""
                             data.append(sp_obj)
                         else:

--- a/scripts/index_distance_checker.py
+++ b/scripts/index_distance_checker.py
@@ -318,27 +318,22 @@ def prepare_index_table(process):
                         elif ONT_PAT.findall(idxs[0]):
                             # ONT barcode - look up sequence from ONT_barcodes.py
                             ont_barcode_name = ONT_PAT.findall(idxs[0])[0]
+                            sp_obj["pool"] = pool_name
+                            sp_obj["proj_id"] = proj_id
+                            sp_obj["sn"] = sample.name.replace(",", "")
+                            sp_obj["idx_name"] = ont_barcode_name
                             try:
                                 barcode_info = get_barcode_info(ont_barcode_name)
-                                sp_obj["pool"] = pool_name
-                                sp_obj["proj_id"] = proj_id
-                                sp_obj["sn"] = sample.name.replace(",", "")
-                                sp_obj["idx_name"] = ont_barcode_name
                                 sp_obj["idx1"] = barcode_info["seq"]
-                                sp_obj["idx2"] = ""
-                                data.append(sp_obj)
                             except KeyError:
                                 # Barcode not found in ONT database
                                 message.append(
                                     f"ONT barcode '{ont_barcode_name}' not found in barcode database for sample {sample.name}"
                                 )
-                                sp_obj["pool"] = pool_name
-                                sp_obj["proj_id"] = proj_id
-                                sp_obj["sn"] = sample.name.replace(",", "")
-                                sp_obj["idx_name"] = ont_barcode_name
                                 sp_obj["idx1"] = ""
-                                sp_obj["idx2"] = ""
-                                data.append(sp_obj)
+                            
+                            sp_obj["idx2"] = ""
+                            data.append(sp_obj)
                         else:
                             sp_obj["pool"] = pool_name
                             sp_obj["proj_id"] = proj_id

--- a/scripts/index_distance_checker.py
+++ b/scripts/index_distance_checker.py
@@ -331,7 +331,6 @@ def prepare_index_table(process):
                                     f"ONT barcode '{ont_barcode_name}' not found in barcode database for sample {sample.name}"
                                 )
                                 sp_obj["idx1"] = ""
-
                             sp_obj["idx2"] = ""
                             data.append(sp_obj)
                         else:


### PR DESCRIPTION
Add comprehensive ONT barcode support across scripts. 
Tested on stage by Nick and Liqun several times.
Three integrated changes for robust ONT barcode handling:

1. ONT_barcodes.py - Add ont_seq2label mapping and get_barcode_info() function
   - Build reverse mapping from sequence to barcode info (ont_seq2label)
   - Add get_barcode_info() handling multiple barcode formats flexibly:
     - Full label: '01_A1_NB01 (CACAAAGACACCGACAACTTTCTT)'
     - Sequence only: 'CACAAAGACACCGACAACTTTCTT'
     - Barcode name: 'NB01', 'BC15', '16S15'
     - Partial label: '01_A1_NB01'
   - Provides clear error messages for unknown barcodes

2. generate_minknow_samplesheet.py - Flexible barcode kit handling
   - Use get_barcode_info() for barcode ID lookup instead of ont_label2dict
   - Allow barcoding with any ONT kit, not just those ending in 24/96
   - New logic processes barcodes if present in library, regardless of kit name
   - Enables use cases like SQK-LSK114 with manual barcode preparation
   - Maintains error checking: dedicated barcode kits without barcodes still error

3. index_distance_checker.py - Add ONT barcode support
   - Import ONT barcode data (get_barcode_info, ont_name2seq)
   - Add ONT_PAT regex: ^(?:NB|BC|RB|BP|RLB|16S)\d{1,2}[A-Z]?$
   - Update barcode recognition in find_barcode() and is_special_idx()
   - Add ONT handling in prepare_index_table() with sequence lookup
   - Support all ONT barcode series (NB, BC, RB, BP, RLB, 16S)

Result: Complete ONT barcode support for samplesheet generation and
index distance checking with flexible format handling
