### PR TITLE
Fix ONT workflow: migrate to Cloudant v1 API and fix reads aggregation

### DIFF
--- a/VERSIONLOG.md
+++ b/VERSIONLOG.md
@@ -1,5 +1,17 @@
 # Scilifelab_epps Version Log
 
+## 20260609.1
+
+Fix ONT workflow: migrate ont_read_stats.py to IBM Cloudant v1 API and fix ONT reads aggregation in readscount.py
+
+## 20260601.1
+
+Fix bug in line splitting
+
+## 20260527.2
+
+Upgrade actions versions ahead of node.js 20 deprecation
+
 ## 20260527.1
 
 Add comprehensive ONT barcode support across scripts

--- a/scripts/ont_read_stats.py
+++ b/scripts/ont_read_stats.py
@@ -4,14 +4,13 @@ import logging
 from argparse import ArgumentParser
 from datetime import datetime as dt
 
-from couchdb.client import Database, Row, ViewResults
-from generate_minknow_samplesheet import get_pool_sample_label_mapping
+from ibmcloudant import cloudant_v1
 from genologics.config import BASEURI, PASSWORD, USERNAME
 from genologics.entities import Artifact, Process, Sample
 from genologics.lims import Lims
 from ont_send_reloading_info_to_db import get_ONT_db
 
-from data.ONT_barcodes import ont_label2dict
+from data.ONT_barcodes import get_barcode_info
 from scilifelab_epps.wrapper import epp_decorator
 
 DESC = """Assign metrics from ONT run onto samples in a LIMS demultiplexing step.
@@ -26,9 +25,8 @@ def main(args):
     process = Process(lims, id=args.pid)
 
     # Connect to database
-    db: Database = get_ONT_db()
-    barcodes_view: ViewResults = db.view("info/barcodes")
-    stats_view: ViewResults = db.view("info/all_stats")
+    client: cloudant_v1.CloudantV1
+    client, db_name = get_ONT_db()
 
     for library in process.all_inputs():
         # Use ONT run name to navigate database
@@ -39,18 +37,38 @@ def main(args):
 
         # Get sample-barcode linkage
         is_barcoded: bool = len(library.samples) > 1
-        sample2label: dict[str, str] = (
-            get_pool_sample_label_mapping(library) if is_barcoded else None
-        )
 
         # For both views, get the row corresponding to the current run
-        stats_row: Row = [row for row in stats_view.rows if run_name == row.key][0]
+        stats_rows: list[dict] = client.post_view(
+            db=db_name,
+            ddoc="info",
+            view="all_stats",
+            include_docs=False,
+            key=run_name,
+        ).get_result()["rows"]
+        if not stats_rows:
+            logging.error(
+                f"No stats entry found in database for run '{run_name}'. Skipping."
+            )
+            continue
+        stats_row: dict = stats_rows[0]
+
         if is_barcoded:
             logging.info("Library seems barcoded.")
-            barcodes_row: Row = [
-                row for row in barcodes_view.rows if run_name == row.key
-            ][0]
-            if not barcodes_row.value:
+            barcodes_rows: list[dict] = client.post_view(
+                db=db_name,
+                ddoc="info",
+                view="barcodes",
+                include_docs=False,
+                key=run_name,
+            ).get_result()["rows"]
+            if not barcodes_rows:
+                logging.error(
+                    "Run database entry does not appear to contain barcodes. Skipping."
+                )
+                continue
+            barcodes_row: dict = barcodes_rows[0]
+            if not barcodes_row.get("value"):
                 logging.error(
                     "Run database entry does not appear to contain barcodes. Skipping."
                 )
@@ -75,21 +93,21 @@ def main(args):
 
             # Get dict containing sequencing run metrics
             if is_barcoded:
-                label: str = sample2label[sample.name]
-                barcode_info: dict = ont_label2dict[label]
+                label: str = demux_art.reagent_labels[0]
+                barcode_info: dict = get_barcode_info(label)
                 barcode_num: int = barcode_info["num"]
                 barcode_generic_name: str = f"barcode{str(barcode_num).zfill(2)}"
                 logging.info(f"Using LIMS label '{label}' as '{barcode_generic_name}'.")
 
-                if not barcodes_row.value.get(barcode_generic_name):
+                if not barcodes_row["value"].get(barcode_generic_name):
                     logging.error(
                         f"Run database entry does not appear to contain data for {barcode_generic_name}. Skipping."
                     )
                     continue
-                metrics: dict = barcodes_row.value[barcode_generic_name]
+                metrics: dict = barcodes_row["value"][barcode_generic_name]
 
             else:
-                metrics: dict = stats_row.value
+                metrics: dict = stats_row["value"]
 
             # Parse and calculate values
             reads_pass = int(metrics.get("basecalled_pass_read_count", "0"))

--- a/scripts/ont_read_stats.py
+++ b/scripts/ont_read_stats.py
@@ -4,10 +4,10 @@ import logging
 from argparse import ArgumentParser
 from datetime import datetime as dt
 
-from ibmcloudant import cloudant_v1
 from genologics.config import BASEURI, PASSWORD, USERNAME
-from genologics.entities import Artifact, Process, Sample
+from genologics.entities import Artifact, Process
 from genologics.lims import Lims
+from ibmcloudant import cloudant_v1
 from ont_send_reloading_info_to_db import get_ONT_db
 
 from data.ONT_barcodes import get_barcode_info
@@ -86,7 +86,6 @@ def main(args):
         logging.info(f"Handling {len(demux_arts)} demultiplexing artifacts.")
 
         for demux_art in demux_arts:
-            sample: Sample = demux_art.samples[0]
             logging.info(
                 f"Processing demultiplexing artifact '{demux_art.name}' ({demux_art.id})."
             )
@@ -121,6 +120,7 @@ def main(args):
             demux_art.udf["Yield PF (Gb)"] = gb_pass
             demux_art.udf["%PF"] = pf_pc
             demux_art.udf["Avg. Read Length"] = avg_len
+            demux_art.udf["Include reads"] = "YES"
 
             # Publish metrics
             demux_art.put()

--- a/scripts/readscount.py
+++ b/scripts/readscount.py
@@ -158,12 +158,26 @@ def sum_reads(sample, summary):
     if sample.name not in summary:
         summary[sample.name] = {}
 
-    # Look for artifacts matching the sample name and expected analyte name in the demultiplexing processeses
-    demux_arts = lims.get_artifacts(
-        sample_name=sample.name,
-        process_type=DEMULTIPLEX_STEPS,
-        name=f"{sample.name} (FASTQ reads)",
-    )
+    # Look for artifacts matching the sample name in the demultiplexing processes.
+    # ONT demux artifacts are named "{sample} (FASTQ reads) {barcode}" so the exact-match
+    # name filter cannot be used; query without name and filter by substring instead.
+    ont_steps = [s for s in DEMULTIPLEX_STEPS if s.startswith("ONT")]
+    non_ont_steps = [s for s in DEMULTIPLEX_STEPS if not s.startswith("ONT")]
+
+    demux_arts = []
+    if non_ont_steps:
+        demux_arts += lims.get_artifacts(
+            sample_name=sample.name,
+            process_type=non_ont_steps,
+            name=f"{sample.name} (FASTQ reads)",
+        )
+    if ont_steps:
+        ont_arts = lims.get_artifacts(
+            sample_name=sample.name,
+            process_type=ont_steps,
+        )
+        demux_arts += [art for art in ont_arts if "(FASTQ reads)" in art.name]
+
     if not demux_arts:
         if sample_has_status(sample, "Aborted"):
             logging.info(

--- a/scripts/readscount.py
+++ b/scripts/readscount.py
@@ -22,6 +22,7 @@ TIMESTAMP: str = dt.now().strftime("%y%m%d_%H%M%S")
 DEMULTIPLEX_STEPS = [
     "Bcl Conversion & Demultiplexing (Illumina SBS) 4.0",
     "ONT Finish Sequencing v3",
+    "ONT Finish Sequencing v2.1",
     "Bcl Conversion & Demultiplexing (AVITI) v1.0",
 ]
 SEQUENCING_STEPS = [


### PR DESCRIPTION
ont_read_stats.py is now correctly populating ONT sequencing metrics (reads, yield, %PF, average read length) on demultiplexing artifacts in the LIMS sequencing step for the first time.
readscount.py is now correctly aggregating ONT read counts for the first time and displaying them on the project summary page.