### PR TITLE
Fix demux noindex and readscount

### DIFF
--- a/VERSIONLOG.md
+++ b/VERSIONLOG.md
@@ -2,6 +2,10 @@
 
 ## 20260724.1
 
+Fix readscount deduplication and noIndex flag leaking across lanes. 
+
+## 20260724.1
+
 Fixing FA attachment files and handling decimal range values due to the FA software version update.
 
 ## 20260722.1

--- a/VERSIONLOG.md
+++ b/VERSIONLOG.md
@@ -2,7 +2,7 @@
 
 ## 20260727.1
 
-Fix readscount deduplication and noIndex flag leaking across lanes. 
+Fix readscount deduplication and no index flag leaking across lanes. 
 
 ## 20260724.1
 

--- a/VERSIONLOG.md
+++ b/VERSIONLOG.md
@@ -1,6 +1,6 @@
 # Scilifelab_epps Version Log
 
-## 20260724.1
+## 20260727.1
 
 Fix readscount deduplication and noIndex flag leaking across lanes. 
 

--- a/VERSIONLOG.md
+++ b/VERSIONLOG.md
@@ -2,7 +2,7 @@
 
 ## 20260727.1
 
-Fix readscount deduplication and no index flag leaking across lanes. 
+Fix demux stats noIndex flag leaking across lanes and readscount deduplication with artifact ID tiebreaker and lane correction detection.
 
 ## 20260724.1
 

--- a/scripts/manage_demux_stats.py
+++ b/scripts/manage_demux_stats.py
@@ -274,7 +274,6 @@ def set_sample_values(demux_process, parser_struct, process_stats):
     )
     failed_entries = 0
     undet_included = False
-    noIndex = False
     undet_lanes = list()
     proj_pattern = re.compile(r"(P\w+_\d+)")
 

--- a/scripts/manage_demux_stats.py
+++ b/scripts/manage_demux_stats.py
@@ -329,6 +329,7 @@ def set_sample_values(demux_process, parser_struct, process_stats):
         lane_reads = 0
         undet_lane_reads = 0
         samplesum = dict()
+        noIndex = False
 
         try:
             outarts_per_lane = []

--- a/scripts/readscount.py
+++ b/scripts/readscount.py
@@ -207,9 +207,97 @@ def sum_reads(sample, summary):
         )
 
     # Iterate across found demux artifacts to aggregate reads and collect flowcell information
+    # First, deduplicate by flowcell+lane, keeping only the latest demux step
+    demux_arts_deduplicated = {}  # key: (flowcell_id, lane), value: demux_artifact
+    for demux_art in demux_arts:
+        # Get flowcell and lane identifiers early for deduplication
+        demux_art_parents = [
+            parent
+            for parent in get_parent_inputs(demux_art)
+            if sample.id in [parent_sample.id for parent_sample in parent.samples]
+        ]
+        if not demux_art_parents or len(demux_art_parents) != 1:
+            continue
+        demux_art_parent = demux_art_parents[0]
+
+        # Determine flowcell key
+        if "ONT flow cell ID" in demux_art_parent.udf:
+            flowcell_key = (demux_art_parent.udf["ONT flow cell ID"], "ONT")
+        else:
+            flowcell_key = (
+                demux_art_parent.location[0].name,
+                demux_art_parent.location[1].split(":")[0],
+            )
+
+        # Keep only the latest by date_run, with artifact ID as tiebreaker
+        if flowcell_key not in demux_arts_deduplicated:
+            demux_arts_deduplicated[flowcell_key] = demux_art
+        else:
+            existing_art = demux_arts_deduplicated[flowcell_key]
+            # Compare date_run: newer (later date) wins
+            existing_date = existing_art.parent_process.date_run
+            new_date = demux_art.parent_process.date_run
+
+            # Extract numeric ID for tiebreaker (e.g., "92-7405142" -> 7405142)
+            existing_id_num = int(existing_art.id.split("-")[1])
+            new_id_num = int(demux_art.id.split("-")[1])
+
+            should_replace = False
+            if new_date is not None and (
+                existing_date is None or new_date > existing_date
+            ):
+                should_replace = True
+            elif new_date == existing_date and new_id_num > existing_id_num:
+                # Same date: use higher artifact ID (created more recently)
+                should_replace = True
+
+            if should_replace:
+                logging.info(
+                    f"Found newer demux artifact for flowcell {flowcell_key}: "
+                    f"replacing {existing_art.id} ({existing_date}) with {demux_art.id} ({new_date})"
+                )
+                demux_arts_deduplicated[flowcell_key] = demux_art
+            else:
+                logging.info(
+                    f"Skipping older demux artifact {demux_art.id} ({new_date}), "
+                    f"keeping {existing_art.id} ({existing_date})"
+                )
+
+    logging.info(
+        f"Deduplicated {len(demux_arts)} artifacts to {len(demux_arts_deduplicated)} "
+        f"(keeping only latest per flowcell+lane)"
+    )
+
+    # Check for lane corrections (sample moved between lanes in different demux steps of same flowcell)
+    flowcell_to_demux_steps = {}  # key: flowcell_id, value: {demux_step_id: set(lanes)}
+    for (flowcell_id, lane), demux_art in demux_arts_deduplicated.items():
+        if flowcell_id not in flowcell_to_demux_steps:
+            flowcell_to_demux_steps[flowcell_id] = {}
+        demux_step_id = demux_art.parent_process.id
+        if demux_step_id not in flowcell_to_demux_steps[flowcell_id]:
+            flowcell_to_demux_steps[flowcell_id][demux_step_id] = set()
+        flowcell_to_demux_steps[flowcell_id][demux_step_id].add(lane)
+
+    for flowcell_id, demux_steps in flowcell_to_demux_steps.items():
+        if len(demux_steps) > 1 and "ONT" not in str(
+            demux_steps
+        ):  # Multiple demux steps
+            all_lanes_across_steps = [lanes for lanes in demux_steps.values()]
+            if len(all_lanes_across_steps) > 1:
+                lanes_step1 = all_lanes_across_steps[0]
+                lanes_step2 = all_lanes_across_steps[1]
+                if lanes_step1 != lanes_step2:
+                    raise ValueError(
+                        f"ERROR: Sample '{sample.name}' appears in different lanes "
+                        f"across demux steps of flowcell '{flowcell_id}': "
+                        f"{dict(demux_steps)}. "
+                        f"This indicates a lane correction in LIMS. "
+                        f"Please verify the values and correct them manually if needed."
+                    )
+
     tot_reads = 0
     flowcell_lane_list = []
-    for demux_art in demux_arts:
+    for demux_art in demux_arts_deduplicated.values():
         logging.info(
             f"Looking at '{demux_art.name}' ({demux_art.id}) of step"
             + f" '{demux_art.parent_process.type.name}'"

--- a/scripts/readscount.py
+++ b/scripts/readscount.py
@@ -189,27 +189,13 @@ def sum_reads(sample, summary):
                 f"Could not find any demultiplexing artifacts for sample {sample.name}."
             )
 
-    # Check for any ongoing demux steps
+    # Iterate across found demux artifacts to aggregate reads and collect flowcell information
+    # Check for ongoing demux steps and deduplicate by flowcell+lane, keeping only the latest demux step
     ongoing_demux_arts = []
+    demux_arts_deduplicated = {}  # key: (flowcell_id, lane), value: demux_artifact
     for demux_art in demux_arts:
         if demux_art.parent_process.date_run is None:
             ongoing_demux_arts.append(demux_art)
-    if ongoing_demux_arts:
-        ongoing_demux_steps_str = ", ".join(
-            [
-                f"'{art.parent_process.type.name}' ({art.parent_process.id})"
-                for art in ongoing_demux_arts
-            ]
-        )
-        logging.warning(
-            f"Sample {sample.name} has demux artifacts in ongoing steps:"
-            + f" {ongoing_demux_steps_str}. Finish them before proceeding."
-        )
-
-    # Iterate across found demux artifacts to aggregate reads and collect flowcell information
-    # First, deduplicate by flowcell+lane, keeping only the latest demux step
-    demux_arts_deduplicated = {}  # key: (flowcell_id, lane), value: demux_artifact
-    for demux_art in demux_arts:
         # Get flowcell and lane identifiers early for deduplication
         demux_art_parents = [
             parent
@@ -262,6 +248,18 @@ def sum_reads(sample, summary):
                     f"Skipping older demux artifact {demux_art.id} ({new_date}), "
                     f"keeping {existing_art.id} ({existing_date})"
                 )
+
+    if ongoing_demux_arts:
+        ongoing_demux_steps_str = ", ".join(
+            [
+                f"'{art.parent_process.type.name}' ({art.parent_process.id})"
+                for art in ongoing_demux_arts
+            ]
+        )
+        logging.warning(
+            f"Sample {sample.name} has demux artifacts in ongoing steps:"
+            + f" {ongoing_demux_steps_str}. Finish them before proceeding."
+        )
 
     logging.info(
         f"Deduplicated {len(demux_arts)} artifacts to {len(demux_arts_deduplicated)} "

--- a/scripts/readscount.py
+++ b/scripts/readscount.py
@@ -228,7 +228,7 @@ def sum_reads(sample, summary):
             existing_id_num = int(existing_art.id.split("-")[1])
             new_id_num = int(demux_art.id.split("-")[1])
 
-                        if (
+            if (
                 new_date is not None
                 and (existing_date is None or new_date > existing_date)
             ) or (new_date == existing_date and new_id_num > existing_id_num):
@@ -238,6 +238,12 @@ def sum_reads(sample, summary):
                     f"replacing {existing_art.id} ({existing_date}) with {demux_art.id} ({new_date})"
                 )
                 demux_arts_deduplicated[flowcell_key] = (demux_art, demux_art_parent)
+            else:
+                logging.info(
+                    f"Skipping older demux artifact {demux_art.id} ({new_date}), "
+                    f"keeping {existing_art.id} ({existing_date})"
+                )
+
     if ongoing_demux_arts:
         ongoing_demux_steps_str = ", ".join(
             [

--- a/scripts/readscount.py
+++ b/scripts/readscount.py
@@ -228,27 +228,16 @@ def sum_reads(sample, summary):
             existing_id_num = int(existing_art.id.split("-")[1])
             new_id_num = int(demux_art.id.split("-")[1])
 
-            should_replace = False
-            if new_date is not None and (
-                existing_date is None or new_date > existing_date
-            ):
-                should_replace = True
-            elif new_date == existing_date and new_id_num > existing_id_num:
+                        if (
+                new_date is not None
+                and (existing_date is None or new_date > existing_date)
+            ) or (new_date == existing_date and new_id_num > existing_id_num):
                 # Same date: use higher artifact ID (created more recently)
-                should_replace = True
-
-            if should_replace:
                 logging.info(
                     f"Found newer demux artifact for flowcell {flowcell_key}: "
                     f"replacing {existing_art.id} ({existing_date}) with {demux_art.id} ({new_date})"
                 )
                 demux_arts_deduplicated[flowcell_key] = (demux_art, demux_art_parent)
-            else:
-                logging.info(
-                    f"Skipping older demux artifact {demux_art.id} ({new_date}), "
-                    f"keeping {existing_art.id} ({existing_date})"
-                )
-
     if ongoing_demux_arts:
         ongoing_demux_steps_str = ", ".join(
             [

--- a/scripts/readscount.py
+++ b/scripts/readscount.py
@@ -192,7 +192,7 @@ def sum_reads(sample, summary):
     # Iterate across found demux artifacts to aggregate reads and collect flowcell information
     # Check for ongoing demux steps and deduplicate by flowcell+lane, keeping only the latest demux step
     ongoing_demux_arts = []
-    demux_arts_deduplicated = {}  # key: (flowcell_id, lane), value: demux_artifact
+    demux_arts_deduplicated = {}  # key: (flowcell_id, lane), value: (demux_artifact, demux_art_parent)
     for demux_art in demux_arts:
         if demux_art.parent_process.date_run is None:
             ongoing_demux_arts.append(demux_art)
@@ -217,9 +217,9 @@ def sum_reads(sample, summary):
 
         # Keep only the latest by date_run, with artifact ID as tiebreaker
         if flowcell_key not in demux_arts_deduplicated:
-            demux_arts_deduplicated[flowcell_key] = demux_art
+            demux_arts_deduplicated[flowcell_key] = (demux_art, demux_art_parent)
         else:
-            existing_art = demux_arts_deduplicated[flowcell_key]
+            existing_art, _ = demux_arts_deduplicated[flowcell_key]
             # Compare date_run: newer (later date) wins
             existing_date = existing_art.parent_process.date_run
             new_date = demux_art.parent_process.date_run
@@ -242,7 +242,7 @@ def sum_reads(sample, summary):
                     f"Found newer demux artifact for flowcell {flowcell_key}: "
                     f"replacing {existing_art.id} ({existing_date}) with {demux_art.id} ({new_date})"
                 )
-                demux_arts_deduplicated[flowcell_key] = demux_art
+                demux_arts_deduplicated[flowcell_key] = (demux_art, demux_art_parent)
             else:
                 logging.info(
                     f"Skipping older demux artifact {demux_art.id} ({new_date}), "
@@ -268,7 +268,7 @@ def sum_reads(sample, summary):
 
     # Check for lane corrections (sample moved between lanes in different demux steps of same flowcell)
     flowcell_to_demux_steps = {}  # key: flowcell_id, value: {demux_step_id: set(lanes)}
-    for (flowcell_id, lane), demux_art in demux_arts_deduplicated.items():
+    for (flowcell_id, lane), (demux_art, _) in demux_arts_deduplicated.items():
         if flowcell_id not in flowcell_to_demux_steps:
             flowcell_to_demux_steps[flowcell_id] = {}
         demux_step_id = demux_art.parent_process.id
@@ -295,7 +295,7 @@ def sum_reads(sample, summary):
 
     tot_reads = 0
     flowcell_lane_list = []
-    for demux_art in demux_arts_deduplicated.values():
+    for demux_art, demux_art_parent in demux_arts_deduplicated.values():
         logging.info(
             f"Looking at '{demux_art.name}' ({demux_art.id}) of step"
             + f" '{demux_art.parent_process.type.name}'"
@@ -319,15 +319,6 @@ def sum_reads(sample, summary):
             continue
 
         assert demux_art.udf["Include reads"] == "YES"
-
-        # Track down the sequencing process upstream of the demux artifact
-        demux_art_parents = [
-            parent
-            for parent in get_parent_inputs(demux_art)
-            if sample.id in [parent_sample.id for parent_sample in parent.samples]
-        ]
-        assert len(demux_art_parents) == 1
-        demux_art_parent = demux_art_parents[0]
 
         # Two cases to consider:
         if demux_art_parent.parent_process.type.name in SEQUENCING_STEPS:


### PR DESCRIPTION
Fix readscount deduplication: add artifact ID tiebreaker and lane correction detection for readscount.py
Fix noIndex flag leaking across lanes: reset noIndex per pool loop iteration for magane_demux_stats.py 
Tested and it works as expected. Related to Deviation Report v.1 #458. 